### PR TITLE
fix build for OS X 10.10 and 10.11

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -59,7 +59,7 @@ echo "[INFO] Compiling portaudio..."
 tar xzf pa.tgz
 cd portaudio
 patch -i ../portaudio_configure_sdk.patch
-./configure && ma/ke
+./configure && make
 
 if ! [ -e "lib/.libs/libportaudio.a"  ]
 then

--- a/compile.sh
+++ b/compile.sh
@@ -58,7 +58,8 @@ cd $DIR
 echo "[INFO] Compiling portaudio..."
 tar xzf pa.tgz
 cd portaudio
-./configure && make
+patch -i ../portaudio_configure_sdk.patch
+./configure && ma/ke
 
 if ! [ -e "lib/.libs/libportaudio.a"  ]
 then
@@ -86,7 +87,7 @@ echo "[INFO] Patching source files..."
 cd $INNER_SRC_DIR
 patch Makefile $DIR/Makefile.patch
 patch event.cpp $DIR/event.cpp.patch
-patch fifo.cpp $DIR/fifo.cpp.patch   
+patch fifo.cpp $DIR/fifo.cpp.patch
 
 # copy the static library libportaudio.a here
 cp $DIR/portaudio/lib/.libs/libportaudio.a .

--- a/portaudio_configure_sdk.patch
+++ b/portaudio_configure_sdk.patch
@@ -1,0 +1,42 @@
+diff -Nru original/configure patched/configure
+--- original/configure	2014-01-16 18:49:33.000000000 +0100
++++ patched/configure	2016-05-12 13:36:45.000000000 +0200
+@@ -15787,7 +15787,8 @@
+         $as_echo "#define PA_USE_COREAUDIO 1" >>confdefs.h
+
+
+-        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Werror"
++        #CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Werror"
++	CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wall"
+         LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework Carbon"
+
+         if test "x$enable_mac_universal" = "xyes" ; then
+@@ -15819,6 +15820,12 @@
+               elif xcodebuild -version -sdk macosx10.9 Path >/dev/null 2>&1 ; then
+                  mac_version_min="-mmacosx-version-min=10.4"
+                  mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.9 Path`"
++              elif xcodebuild -version -sdk macosx10.10 Path >/dev/null 2>&1 ; then
++                 mac_version_min="-mmacosx-version-min=10.4"
++                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.10 Path`"
++              elif xcodebuild -version -sdk macosx10.11 Path >/dev/null 2>&1 ; then
++                 mac_version_min="-mmacosx-version-min=10.4"
++                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.11 Path`"
+               else
+                  as_fn_error $? "Couldn't find 10.5, 10.6, 10.7, 10.8 or 10.9 SDK" "$LINENO" 5
+               fi
+diff -Nru original/configure.in patched/configure.in
+--- original/configure.in	2014-01-16 18:49:33.000000000 +0100
++++ patched/configure.in	2016-05-12 13:36:45.000000000 +0200
+@@ -249,6 +249,12 @@
+               elif xcodebuild -version -sdk macosx10.9 Path >/dev/null 2>&1 ; then
+                  mac_version_min="-mmacosx-version-min=10.4"
+                  mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.9 Path`"
++              elif xcodebuild -version -sdk macosx10.10 Path >/dev/null 2>&1 ; then
++                 mac_version_min="-mmacosx-version-min=10.4"
++                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.10 Path`"
++              elif xcodebuild -version -sdk macosx10.11 Path >/dev/null 2>&1 ; then
++                 mac_version_min="-mmacosx-version-min=10.4"
++                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.11 Path`"
+               else
+                  AC_MSG_ERROR([Couldn't find 10.5, 10.6, 10.7, 10.8 or 10.9 SDK])
+               fi


### PR DESCRIPTION
The current script fails for OS X installations with SDKs 10.9 or lower. I've applied a patch with the changes described in [1].

[1] https://www.assembla.com/spaces/portaudio/tickets/240-problem-configure-sdks-not-found-with-new-xcode-7-0-update--amp--command-line-tools-(os-x-10-10)/details
